### PR TITLE
Patch 1

### DIFF
--- a/Documentation/AdministratorManual/Constants/Index.rst
+++ b/Documentation/AdministratorManual/Constants/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../Includes.txt
 
 .. _ts-constants:
 
@@ -11,7 +11,7 @@ Constants
 =========
 
 This page is divided into the following sections which are all configurable by using TypoScript or the constant editor:
-All constants could be configured once per site. 
+All constants could be configured once per site.
 
 .. only:: html
 
@@ -45,10 +45,10 @@ pluginStoragePid
       :ref:`t3tsref:data-type-integer`
 
    Description
-      General storage page where all records are stored. 
+      General storage page where all records are stored.
 
    Default
-      \ 
+      \
 
 plugin.tx_thrating.config
 -------------------------
@@ -63,7 +63,7 @@ plugin.tx_thrating.config
    cookieLifetime_                      Cookie protection lifetime             int
    mapAnonymous_                        Map UID to anonymous user              int
    ==================================== ====================================== ===============
-   
+
 
 .. _constLoadJQuery:
 
@@ -83,8 +83,8 @@ loadJQuery
 
    Default
       :ts:`1`
-      
-      
+
+
 .. _constShowNoFEUser:
 
 showNoFEUser
@@ -159,8 +159,8 @@ plugin.tx_thrating.view
    partialRootPath_                     path directive                         string
    layoutRootPath_                      path directive                         string
    ==================================== ====================================== ===============
-   
-   
+
+
 .. _constTemplateRootPath:
 
 templateRootPath
@@ -181,7 +181,7 @@ templateRootPath
       :ts:`EXT:th_rating/Resources/Private/Templates/`
 
 
-      
+
 .. _constPartialRootPath:
 
 partialRootPath

--- a/Documentation/AdministratorManual/Data model/Index.rst
+++ b/Documentation/AdministratorManual/Data model/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../Includes.txt
 
 .. _data-model:
 
@@ -28,9 +28,9 @@ Except the objecttype ``Tx_Extbase_Domain_Model_FrontendUser`` which is build in
 .. container::
 
    ====================================== ======================================
-   Property                               Title                                 
+   Property                               Title
    ====================================== ======================================
-   Tx_ThRating_Domain_Model_Ratingobject_ Root entity holds rating objects                 
+   Tx_ThRating_Domain_Model_Ratingobject_ Root entity holds rating objects
    Tx_ThRating_Domain_Model_Stepconf_     Storing the step configuration
    Tx_ThRating_Domain_Model_Stepname_     Language aware names of the steps
    Tx_ThRating_Domain_Model_Rating_       Concrete instances of ratingobects
@@ -52,8 +52,8 @@ Holds the basic information on anything you´d like to rate
    Tx_ThRating_Domain_Model_Stepconf)
 -  ratings: To do ratings on each row of a table this link is
    required (see Tx_ThRating_Domain_Model_Rating)
-      
-      
+
+
 
 Tx_ThRating_Domain_Model_Stepconf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/AdministratorManual/Index.rst
+++ b/Documentation/AdministratorManual/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _admin-manual:
 

--- a/Documentation/AdministratorManual/Installation/Index.rst
+++ b/Documentation/AdministratorManual/Installation/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../Includes.txt
 
 .. _installation:
 
@@ -22,13 +22,13 @@ Installation
 #. Reference to the container for extension data
 
    Create a new sysfolder or choose an existing one and write down the PID.
-   Open the TS Constant Editor and at least set the value in ``[plugin.tx_thrating.settings.pluginStoragePid]`` 
+   Open the TS Constant Editor and at least set the value in ``[plugin.tx_thrating.settings.pluginStoragePid]``
    to the former written down PID of the sysfolder
-       
+
    |Install_Constants|
 
 #. Reference to the container for Website users
 
    Create another folder designated as a container for Website Users and again write down the PID.
    Now open your website template and add the following configuration setup:
-   :ts:`plugin.tx_felogin_pi1.storagePid = <PID of the website users container>` 
+   :ts:`plugin.tx_felogin_pi1.storagePid = <PID of the website users container>`

--- a/Documentation/AdministratorManual/Typoscript/Index.rst
+++ b/Documentation/AdministratorManual/Typoscript/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../Includes.txt
 
 .. _ts-settings:
 
@@ -22,7 +22,7 @@ Please scan the following sections to find out what is configurable by using Typ
    RichSnippetLibs
    settings/Index
 
-   
+
 :ts:`plugin.tx_thrating`
 ************************
 
@@ -62,7 +62,7 @@ action
 
    Description
       MVC-Action to activa. Possible values:
-      
+
       - :typoscript:`ratinglinks`
          Graphical presentation to do and to display ratings
 
@@ -76,26 +76,26 @@ action
          Display the actual vote of the currently logged on FE user in plain text
 
       -  :typoscript:`new`
-         Generate a classic form element (default: drop-drown select field) for voting. 
+         Generate a classic form element (default: drop-drown select field) for voting.
          If the user has already voted action :typoscript:`show` is used.
-      
+
       .. important::
-      
+
          Whatever value is configured here it must also be set in :typoscript:`plugin.tx_thrating.switchableControllerActions.Vote`:
-      
+
          .. code-block:: typoscript
-         
+
             plugin.tx_thrating.switchableControllerActions {
                Vote {
                   1 = ratinglinks
                }
             }
-      
+
    Default
       :ts:`ratinglinks`
 
-      
-      
+
+
 Example
 -------
 
@@ -110,4 +110,3 @@ Example
             1 = polling
          }
       }
-      

--- a/Documentation/AdministratorManual/Typoscript/Ratings.name.rst
+++ b/Documentation/AdministratorManual/Typoscript/Ratings.name.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../Includes.txt
 
 
 .. _ts-pluginThRatingsName:
@@ -19,7 +19,7 @@ This page is divided into the following sections:
         :local:
         :depth: 2
 
-Each rating could have a special graphical configuration. Use this section to configure it. 
+Each rating could have a special graphical configuration. Use this section to configure it.
 The configurations are seperated into subsections identified by a distinct name.
 
 Within each you could do all typoscript settings described in :ref:`ts-pluginThRatingSettings`
@@ -27,10 +27,10 @@ and :ref:`ts-pluginThRatingSettingsFluid` (see :ref:`ts-pluginThRatingsNameExamp
 
 Best practice would be to include such configuration in your own template.
 It is recommended to use distinct names for your ratingconfigurations.
-Additionally - if you'd like to adjust the default given configurations - remember that your settings 
-will override or enhance the default settings. But it is not possible to delete settings of the default. 
+Additionally - if you'd like to adjust the default given configurations - remember that your settings
+will override or enhance the default settings. But it is not possible to delete settings of the default.
 It is recommended to just copy the configuration you want from the file ``EXT:th_rating/Configuration/TypoScript/setup.txt``
-or take one from the examples in this documentation. Then choose a different name and make your adjustments as you want. 
+or take one from the examples in this documentation. Then choose a different name and make your adjustments as you want.
 
 
 Reference
@@ -62,10 +62,10 @@ imagefile
 
    Description
       Imagename of the graphical representation including path.
-      Path must be given relative to SITE_ROOT (e.g. ``typo3conf/ext/th_rating/Resources/Public/Css/stars.gif``) 
+      Path must be given relative to SITE_ROOT (e.g. ``typo3conf/ext/th_rating/Resources/Public/Css/stars.gif``)
 
    Default
-      \ 
+      \
 
 .. _tsBarimage:
 
@@ -87,7 +87,7 @@ barimage
       :ts:`0`
 
 
-   
+
 .. _tsTilt:
 
 tilt
@@ -186,6 +186,6 @@ the imagetype in a manner as follows:
 
 The table shows all preconfigured rating configuration and their names.
 
-All icons (except those of the type barrating) are taken from `http://openiconlibrary.sourceforge.net/`_. 
+All icons (except those of the type barrating) are taken from `http://openiconlibrary.sourceforge.net/`_.
 All upper listed icons are licensed by GPL2 or PD. I appreciate the great work of those authors.
 Anyway, if the usage of any icon hits the copyright of any person I´d ask this person to drop me a mail if he/she want me to remove it.

--- a/Documentation/AdministratorManual/Typoscript/RichSnippetLibs.rst
+++ b/Documentation/AdministratorManual/Typoscript/RichSnippetLibs.rst
@@ -3,18 +3,18 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../Includes.txt
 
 
 .. _ts-richSnippetLibs:
 
 ~.richSnippetLibs
 =================
-      
-This extension provides support for `Google rich snippets`_. 
+
+This extension provides support for `Google rich snippets`_.
 You may enhance the information included in each rating using some typoscript library definitions.
 The following paths will be used:
-  
+
 
 .. container:: ts-properties
 
@@ -40,15 +40,15 @@ lib.thrating.ratedObjectUrl
 
    Description
       URL to the rated item.
-      If no or an invalid name is given, the default value consists of the current URL, 
+      If no or an invalid name is given, the default value consists of the current URL,
       the constant text "RatingAX" appendixed by the UID values of the ratingobject and the rated object.
       (e.g. "``RatingAX_2_30``" meaning ratingobject #2 / ratedobject #30).
 
    Default
       ``[scheme]://[host][:[port]][path_script]?id=[page_uid]#RatingAX_xx_yy``
-      
 
-         
+
+
 .. _rslRatedObjectImage:
 
 lib.thrating.ratedObjectImage
@@ -63,7 +63,7 @@ lib.thrating.ratedObjectImage
       :ref:`t3tsref:cobj-img-resource`
 
    Description
-      Reference to an image of the rated object.  
+      Reference to an image of the rated object.
 
    Default
-      \ 
+      \

--- a/Documentation/AdministratorManual/Typoscript/settings/Index.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _ts-pluginThRatingSettings:
@@ -76,7 +76,7 @@ display
 
    Default
       different depending on action
- 
+
 
 .. _tsRatetable:
 
@@ -96,7 +96,7 @@ ratetable
 
    Default
       :ts:`tt_content`
- 
+
 
 .. _tsRatefield:
 
@@ -116,7 +116,7 @@ ratefield
 
    Default
       :ts:`uid`
- 
+
 
 .. _tsRatingContext:
 
@@ -136,7 +136,7 @@ ratingContext
 
    Default
       :ts:`defaultContext`
- 
+
 
 .. _tsRatingobject:
 
@@ -155,8 +155,8 @@ ratingobject
       UID of the ratingobject. Could be helpful to increase performance instead of using ratetable/ratefield combination.
 
    Default
-      \ 
- 
+      \
+
 .. _tsRatedobjectuid:
 
 ratedobjectuid
@@ -174,8 +174,8 @@ ratedobjectuid
       UID of the rated row in the table
 
    Default
-      
- 
+
+
 .. _tsMapAnonymous:
 
 mapAnonymous
@@ -194,7 +194,7 @@ mapAnonymous
 
    Default
       see constant :ref:`constMapAnonymous`
- 
+
 .. _tsCookieLifetime:
 
 cookieLifetime
@@ -214,7 +214,7 @@ cookieLifetime
    Default
       :ts:`0`
 
- 
+
 .. _tsShowNoFEUser:
 
 showNoFEUser
@@ -254,7 +254,7 @@ showNotRated
    Default
       :ts:`0`
 
- 
+
 .. _tsDisplayOnly:
 
 displayOnly
@@ -274,7 +274,7 @@ displayOnly
    Default
       :ts:`0`
 
- 
+
 .. _tsEnableReVote:
 
 enableReVote
@@ -294,7 +294,7 @@ enableReVote
    Default
       :ts:`0`
 
- 
+
 .. _tsForeignFieldArrayUpdate:
 
 foreignFieldArrayUpdate
@@ -309,12 +309,12 @@ foreignFieldArrayUpdate
       :ref:`t3tsref:data-type-boolean`
 
    Description
-      Update foreign ratetable in ratefield using the whole getCurrentRates array or double value (default) 
+      Update foreign ratetable in ratefield using the whole getCurrentRates array or double value (default)
 
    Default
       :ts:`0`
 
- 
+
 .. _tsStoragePid:
 
 storagePid
@@ -329,12 +329,12 @@ storagePid
       :ref:`t3tsref:data-type-integer`
 
    Description
-      General storage page where all records are stored. 
+      General storage page where all records are stored.
 
    Default
       value of constant :ref:`constPluginStoragePid`
 
- 
+
 **Example**
 
 Here an example which is also included in one of the default configurations:

--- a/Documentation/AdministratorManual/Typoscript/settings/Logging.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/Logging.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../Includes.txt
 
 .. _ts-pluginThRatingSettingsLogging:
 
@@ -17,8 +17,8 @@
         :depth: 3
 
 
-This extension makes use of the logging framework which was newly introduced in TYPO3 6.1. 
-For more information on this look at `Logging with TYPO3`_ in the TYPO3 Core API. 
+This extension makes use of the logging framework which was newly introduced in TYPO3 6.1.
+For more information on this look at `Logging with TYPO3`_ in the TYPO3 Core API.
 For each log level as there are
 
 -  :ts:`emergency`
@@ -66,8 +66,8 @@ file
       Filename to store log messages.
 
    Default
-      \ 
- 
+      \
+
 
 .. _tsLoggingTable:
 
@@ -86,9 +86,9 @@ table
       Tablename to store log messages
 
    Default
-      \ 
+      \
 
-      
+
 Example
 -------
 
@@ -101,4 +101,3 @@ Example
          table = sys_log
       }
    }
-   

--- a/Documentation/AdministratorManual/Typoscript/settings/RichSnippetFields.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/RichSnippetFields.rst
@@ -3,17 +3,17 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _ts-richSnippetFields:
 
 ~.richSnippetFields
 ===================
-      
-This extension provides support for `Google rich snippets`_. 
+
+This extension provides support for `Google rich snippets`_.
 Setting the following options some meta information could be configured which is being read from the database for each rated item.
-The configured options must be field descriptors in the rated table. 
+The configured options must be field descriptors in the rated table.
 
 .. container:: ts-properties
 
@@ -43,7 +43,7 @@ name
 
    Description
       Fieldname to fetch the item name from.
-      If no or an invalid name is given, the default value consists of the constant text "Rating AX" 
+      If no or an invalid name is given, the default value consists of the constant text "Rating AX"
       appendixed by the UID values of the ratingobject and the rated object.
       (e.g. "``Rating AX 2_30``" meaning ratingobject #2 / ratedobject #30).
 
@@ -64,12 +64,12 @@ description
       :ref:`t3tsref:data-type-string`
 
    Description
-      Fieldname to fetch the item description from 
+      Fieldname to fetch the item description from
 
    Default
-      \       
-      
-      
+      \
+
+
 Example
 -------
 
@@ -86,7 +86,7 @@ Example
          }
       }
    }
-   
+
 
 .. _rsfAggregateRatingSchemaType:
 
@@ -113,7 +113,7 @@ aggregateRatingSchemaType
          - ``Service``
 
       .. warning::
-      
+
          Any other value will cause an exception during frontend rendering.
 
    Default

--- a/Documentation/AdministratorManual/Typoscript/settings/fluid/Index.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/fluid/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../../Includes.txt
 
 
 .. _ts-pluginThRatingSettingsFluid:
@@ -11,8 +11,8 @@
 ~.fluid
 =======
 
-The layout of the extension could be manipulated using this section. 
-All settings here could be overridden by the configuration set in :ref:`ts-pluginThRatingsName`. 
+The layout of the extension could be manipulated using this section.
+All settings here could be overridden by the configuration set in :ref:`ts-pluginThRatingsName`.
 The section is deeply divided in subsections:
 
 .. toctree::

--- a/Documentation/AdministratorManual/Typoscript/settings/fluid/Layouts.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/fluid/Layouts.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../../Includes.txt
 
 .. _ts-pluginThRatingSettingsFluidLayouts:
 
@@ -16,7 +16,7 @@ At this point of time the extension uses two layouts:
 #. ``PollingLayout`` only for action handler :ts:`polling`
 
 You may take a look at the file for better understanding the following options.
- 
+
 .. only:: html
 
    .. contents::
@@ -58,7 +58,7 @@ showSummary
 
    Default
       :ts:`1`
- 
+
 
 .. _tsShowCurrentRatesDefault:
 
@@ -78,7 +78,7 @@ showCurrentRates
 
    Default
       :ts:`1`
- 
+
 
 .. _tsShowSectionContentDefault:
 
@@ -98,8 +98,8 @@ showSectionContent
 
    Default
       :ts:`1`
- 
- 
+
+
 Reference PollingLayout
 -----------------------
 
@@ -133,8 +133,8 @@ showSummary
 
    Default
       :ts:`0`
- 
- 
+
+
 .. _tsShowCurrentRatesPoll:
 
 showCurrentRates

--- a/Documentation/AdministratorManual/Typoscript/settings/fluid/Partials.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/fluid/Partials.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../../Includes.txt
 
 .. _ts-pluginThRatingSettingsFluidPartials:
 
@@ -52,7 +52,7 @@ showTextInfo
 
    Default
       :ts:`1`
- 
+
 
 .. _tsShowGraphicInfo:
 
@@ -72,9 +72,9 @@ showGraphicInfo
 
    Default
       :ts:`0`
- 
 
- 
+
+
 Reference ~.infoBlock
 ---------------------
 

--- a/Documentation/AdministratorManual/Typoscript/settings/fluid/Templates.rst
+++ b/Documentation/AdministratorManual/Typoscript/settings/fluid/Templates.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../../../../Includes.txt
 
 .. _ts-pluginThRatingSettingsFluidTemplates:
 
@@ -48,9 +48,9 @@ tooltips
 
    Description
       Activate HTML tooltips on hover over ratinglinks.
-      
+
       |Typoscript_Ratinglink_tooltip|
-      
+
 
    Default
       :ts:`1`

--- a/Documentation/DeveloperInformation/ExtensionManagementService.rst
+++ b/Documentation/DeveloperInformation/ExtensionManagementService.rst
@@ -3,16 +3,16 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _extensionManagementService:
 
 ExtensionManagement Service
 ===========================
 
-This service object provides developers support for generating 
-ratingobjects, stepconfs and localized stepnames automatically. 
-This could be an easy to use alternative to manually creating them via backend. 
+This service object provides developers support for generating
+ratingobjects, stepconfs and localized stepnames automatically.
+This could be an easy to use alternative to manually creating them via backend.
 
 Two methods are avaiable:
 
@@ -20,7 +20,7 @@ Two methods are avaiable:
 - ``setStepname``
 
 
-This section describes the mentioned methoed and tries to give you an example how to cope with them. 
+This section describes the mentioned methoed and tries to give you an example how to cope with them.
 
 .. only:: html
 
@@ -58,8 +58,8 @@ This function has to be called providing three parameters:
    +------------------+--------------------------------------------------------------------------------------+-------------+
 
    ``[makeRatable]``
-   
-   
+
+
 
 
 setStepname
@@ -110,7 +110,7 @@ Parameter $stepconf
       The stepconf object which has to be described
 
    Default
-      \ 
+      \
 
 
 .. _$stepname:
@@ -126,10 +126,10 @@ Parameter $stepname
       ``String``
 
    Description
-      The localized description text 
+      The localized description text
 
    Default
-      \ 
+      \
 
 
 .. _$languageIso2Code:
@@ -145,7 +145,7 @@ Parameter $languageIso2Code
       ``Integer``
 
    Description
-      The ISO2 language code (e.g. ``43`` = German) 
+      The ISO2 language code (e.g. ``43`` = German)
 
    Default
       ``0``
@@ -164,10 +164,10 @@ Parameter $allStepconfs
       ``Boolean``
 
    Description
-      Switch to initialize all stepnames with the same value. 
-      On ``TRUE`` all stepconfs of the ratingobject will be configured with this text. 
+      Switch to initialize all stepnames with the same value.
+      On ``TRUE`` all stepconfs of the ratingobject will be configured with this text.
       The steporder number will be appended to the stepname.
-      
+
    Default
       ``FALSE``
 
@@ -175,15 +175,15 @@ Parameter $allStepconfs
 .. important::
 
    If an entry for the stepname already exists nothing will be changed.
-   
-   
+
+
 Example
 -------
 
 1. Create initial rating config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Let´s try to create an initial rating configuration for the field ``Testfield`` in table ``Testtable``. 
+Let´s try to create an initial rating configuration for the field ``Testfield`` in table ``Testtable``.
 We need 4 ratingsteps even weighted.
 This example assumes that we´re in an extbase controller context.
 Basically it could be also a guide for "old" pi_based extensions.
@@ -201,8 +201,8 @@ We store the reference on the generated new ratingobject in a variable.
 2. Add stepnames
 ^^^^^^^^^^^^^^^^
 
-Next the rating stepnames could be added according to our extension needs. 
-In this example we assume any default language and an additional 
+Next the rating stepnames could be added according to our extension needs.
+In this example we assume any default language and an additional
 website language ``German`` (``UID 43`` in the table ``static_languages``):
 
 .. code:: php
@@ -211,38 +211,38 @@ website language ``German`` (``UID 43`` in the table ``static_languages``):
     $this->objectManager
       ->get('Thucke\\ThRating\\Service\\ExtensionManagementService')
       ->setStepname($ratingobject->getStepconfs()->current(), 'Automatic generated entry ', 0, TRUE);
-      
+
     //add descriptions in german language to each stepconf
     $this->objectManager
       ->get('Thucke\\ThRating\\Service\\ExtensionManagementService')
-      ->setStepname($ratingobject->getStepconfs()->current(), 'Automatischer Eintrag ', 43, TRUE);      
+      ->setStepname($ratingobject->getStepconfs()->current(), 'Automatischer Eintrag ', 43, TRUE);
 
 
-Among others the table ``static_languages`` will be installed by the extension `static_info_tables`_ 
+Among others the table ``static_languages`` will be installed by the extension `static_info_tables`_
 Find the row of the language you need and write down the value of ``UID`` - which is ``43`` for German.
-If we like to add other languages to our stepconfs we just have to find out the correct language ISO2 code 
+If we like to add other languages to our stepconfs we just have to find out the correct language ISO2 code
 e.g. by checking the table ``static_languages``.
 
-You may also use 
+You may also use
 
 .. code:: php
-  
+
    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate
 
-for fetching the concrete text. 
+for fetching the concrete text.
 Then it is recommended that all possible language entries for the stepnames have to reside
-in the default language XLF of your extension. 
+in the default language XLF of your extension.
 
-The following example assumes that the file ``locallang.xlf`` of the extension ``MyExtenion`` 
+The following example assumes that the file ``locallang.xlf`` of the extension ``MyExtenion``
 stores its text in ``rating.<ratingfield>.stepconf.step<steporder>.<ISO2Code>``:
 
 .. code:: php
 
     //add descriptions in default language to each stepconf
-    $this->objectManager->get('Thucke\\ThRating\\Service\\ExtensionManagementService')->setStepname($ratingobject->getStepconfs()->current(), 
+    $this->objectManager->get('Thucke\\ThRating\\Service\\ExtensionManagementService')->setStepname($ratingobject->getStepconfs()->current(),
        \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('rating.testfield.stepconf.step1.30', 'MyExtension'), 0, TRUE);
     //add descriptions in german language to each stepconf
-    $this->objectManager->get('Thucke\\ThRating\\Service\\ExtensionManagementService')->setStepname($ratingobject->getStepconfs()->current(), 
+    $this->objectManager->get('Thucke\\ThRating\\Service\\ExtensionManagementService')->setStepname($ratingobject->getStepconfs()->current(),
        \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('rating.testfield.stepconf.step1.43', 'MyExtension'), 43, TRUE);
 
 

--- a/Documentation/DeveloperInformation/Index.rst
+++ b/Documentation/DeveloperInformation/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _dev-information:
 
@@ -12,7 +12,7 @@ Developer Information
 
 Target group: **Developers**
 
-The extension provides some features supporting developers embedding Rating AX into their extensions.  
+The extension provides some features supporting developers embedding Rating AX into their extensions.
 
 .. toctree::
    :maxdepth: 3

--- a/Documentation/DeveloperInformation/LocalizationSupport.rst
+++ b/Documentation/DeveloperInformation/LocalizationSupport.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _localization-support:
 
@@ -17,13 +17,13 @@ Localization support
 
 The extension currently covers localizations for the following languages
 
-- German 
+- German
 - English
 
-Translations could be easily added and maintained via the `official localization server`_. 
+Translations could be easily added and maintained via the `official localization server`_.
 
 .. important::
 
-   Everone is encouraged providing translation support. 
+   Everone is encouraged providing translation support.
 
 .. _official localization server: http://translation.typo3.org/projects/TYPO3.ext.th_rating/

--- a/Documentation/DeveloperInformation/SignalSlotSupport.rst
+++ b/Documentation/DeveloperInformation/SignalSlotSupport.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _signal-slot-support:
 
@@ -15,7 +15,7 @@ Signal / Slot support
    :titlesonly:
 
 
-Rating AX provides support for the signal / slot messaging feature of extbase. 
+Rating AX provides support for the signal / slot messaging feature of extbase.
 Currently the extension will "listen" for two signals:
 
 -  ``afterRatinglinkAction``
@@ -41,7 +41,7 @@ signalSlotMessage
 This hashtable provides the registered signalslot with some data upon the actual handled ratedobject.
 The keys are described in the following tables.
 
-   
+
 .. container:: table-row
 
    Property
@@ -49,11 +49,11 @@ The keys are described in the following tables.
 
    Data type
       ``String``
-         
+
    Description
       The tablename of the rated object
 
-         
+
 .. container:: table-row
 
    Property
@@ -61,10 +61,10 @@ The keys are described in the following tables.
 
    Data type
       ``String``
-         
+
    Description
       The fieldname of the rated object
-         
+
 
 .. container:: table-row
 
@@ -73,7 +73,7 @@ The keys are described in the following tables.
 
    Data type
       ``Integer``
-         
+
    Description
       The uid of the rated object
 
@@ -85,16 +85,16 @@ The keys are described in the following tables.
 
    Data type
       ``Array``
-         
+
    Description
       Contains information representing the actual rating statistics
-      
+
       .. _currentRatesKeys:
-      
+
       .. container::
 
          ``[Keys of hashtable currentRates]``
-      
+
          +-----------------------------------+---------------------------------------------------------------+---------------+
          | Key                               | Description                                                   | Type          |
          +===================================+===============================================================+===============+
@@ -128,11 +128,11 @@ The keys are described in the following tables.
       |
 
       .. _currentPollDimensionsKeys:
-      
+
       .. container::
-      
+
          ``[Keys of hashtable currentPollDimensions]``
-         
+
          ==================================== ============================================================= ================
          Key                                  Description                                                   Type
          ==================================== ============================================================= ================
@@ -151,7 +151,7 @@ The  registered slothandler could fill this array with pure HTML code wich will 
 .. container::
 
    ==================================== ====================================================================================
-   Parameter                            Description                                   
+   Parameter                            Description
    ==================================== ====================================================================================
    ``staticPreContent``                 this content will be included in front of the extension output (NOT changed by AJAX)
    ``staticPostContent``                this content will be included after the extension output (NOT changed by AJAX)
@@ -159,10 +159,10 @@ The  registered slothandler could fill this array with pure HTML code wich will 
    ``postContent``                      this content will be included after the extension output (changed by AJAX)
    ==================================== ====================================================================================
 
- 
+
 The following picture will help you understand the different sections of the extension output.
-  
+
 |ThRating_defaultLayout|
-  
+
 Using the right CSS formattings it would be easy to arrange the different sections for your specific needs.
 

--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -34,112 +34,112 @@
 .. DEFINE Image aliases
 .. --------------------------------------------------
 
-.. |img-1| image:: /Documentation/Images/manual_html_22ebf792.gif
+.. |img-1| image:: Images/manual_html_22ebf792.gif
    :align: middle
 
-.. |img-2| image:: /Documentation/Images/manual_html_3c9c2593.png
+.. |img-2| image:: Images/manual_html_3c9c2593.png
    :height: 21
    :width: 87
 
-.. |example1| image:: /Documentation/Images/th_rating_example1.png
+.. |example1| image:: Images/th_rating_example1.png
    :alt: Example 1 - classic starrating
-   :align: top      
+   :align: top
 
-.. |example2| image:: /Documentation/Images/th_rating_example2.png
+.. |example2| image:: Images/th_rating_example2.png
    :alt: Example 2 - barrating
-   :align: top      
+   :align: top
 
-.. |example3| image:: /Documentation/Images/th_rating_example3.png
+.. |example3| image:: Images/th_rating_example3.png
    :alt: Example 3 - vertical classic starrating
-   :align: top      
+   :align: top
 
-.. |example4| image:: /Documentation/Images/th_rating_example4.png
+.. |example4| image:: Images/th_rating_example4.png
    :alt: Example 4 - current rating (text)
-   :align: top      
+   :align: top
    :width: 350
 
-.. |example5| image:: /Documentation/Images/th_rating_example5.png
-   :alt: Example 5 - current rating (classic starrating) 
-   :align: top      
+.. |example5| image:: Images/th_rating_example5.png
+   :alt: Example 5 - current rating (classic starrating)
+   :align: top
    :width: 350
 
-.. |example6| image:: /Documentation/Images/th_rating_example6.png
+.. |example6| image:: Images/th_rating_example6.png
    :alt: Example 6 - vote form
-   :align: top      
+   :align: top
    :width: 350
 
-.. |example7| image:: /Documentation/Images/th_rating_example7.png
+.. |example7| image:: Images/th_rating_example7.png
    :alt: Example 7 - vertical rating
-   :align: top      
+   :align: top
 
-.. |example8| image:: /Documentation/Images/th_rating_example8.png
+.. |example8| image:: Images/th_rating_example8.png
    :alt: Example 8 - polling mode
-   :align: top      
-   
-.. |example9| image:: /Documentation/Images/th_rating_example9.gif
-   :alt: Example 8 - polling mode
-   :align: top      
+   :align: top
 
-.. |ManualNewContentElement.png| 	image:: /Documentation/Images/UsersManual/ManualNewContentElement.png
+.. |example9| image:: Images/th_rating_example9.gif
+   :alt: Example 8 - polling mode
+   :align: top
+
+.. |ManualNewContentElement.png|    image:: Images/UsersManual/ManualNewContentElement.png
    :alt: Create new content element in BE
-   :align: top      
+   :align: top
    :width: 450
 
-.. |ManualContentElementPlugin.png| image:: /Documentation/Images/UsersManual/ManualContentElementPlugin.png
+.. |ManualContentElementPlugin.png| image:: Images/UsersManual/ManualContentElementPlugin.png
    :alt: Choose the extension “Rating AX” in the dropdownbox
-   :align: top      
+   :align: top
    :width: 450
 
-.. |ManualContentElementObject.png| image:: /Documentation/Images/UsersManual/ManualContentElementObject.png
+.. |ManualContentElementObject.png| image:: Images/UsersManual/ManualContentElementObject.png
    :alt: Edit ratingobject
-   :align: top      
+   :align: top
    :width: 450
 
-.. |ManualRatingstepMultilang.png| 	image:: /Documentation/Images/UsersManual/ManualRatingstepMultilang.png
+.. |ManualRatingstepMultilang.png|    image:: Images/UsersManual/ManualRatingstepMultilang.png
    :alt: Edit ratingstep names (multilingual)
-   :align: top      
+   :align: top
    :width: 450
 
-.. |Install_EM| 					image:: /Documentation/Images/AdministratorManual/Install_EM.png
+.. |Install_EM|                image:: Images/AdministratorManual/Install_EM.png
    :alt: Extension installation in EM
-   :align: top      
+   :align: top
    :width: 600
 
-.. |Install_InclTemplate| 			image:: /Documentation/Images/AdministratorManual/Install_InclTemplate.png
+.. |Install_InclTemplate|          image:: Images/AdministratorManual/Install_InclTemplate.png
    :alt: Include the template
-   :align: top      
+   :align: top
    :width: 450
 
-.. |Install_Constants| 				image:: /Documentation/Images/AdministratorManual/Install_Constants.png
+.. |Install_Constants|             image:: Images/AdministratorManual/Install_Constants.png
    :alt: Set needed constants
-   :align: top      
+   :align: top
    :width: 450
 
 .. _`http://openiconlibrary.sourceforge.net/`: http://openiconlibrary.sourceforge.net/
 
-.. |File_Req_nr.png| 				image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_nr.png
-.. |File_Req_r.png| 				image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_r.png
-.. |File_Req_cr.png|				image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_cr.png
-.. |File_Req_classic_starrating|	image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_classic_starrating.png
-.. |File_Req_barrating|				image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_barrating.png
-.. |File_Req_smiley|				image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_smiley.png
-.. |File_Req_tilt_barrating|		image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_tilt_barrating.png
-.. |File_Req_tilt_starrating|		image:: /Documentation/Images/AdministratorManual/Typoscript/File_Req_tilt_starrating.png
-.. |Typoscript_Ratinglink_tooltip|	image:: /Documentation/Images/AdministratorManual/Typoscript/Ratinglink_tooltip_example.png
-.. |ThRating_defaultLayout|		    image:: /Documentation/Images/DeveloperInformation/ThRating_defaultLayout.gif
-.. |BE_RatingObjects.png| 			image:: /Documentation/Images/Tutorial/BE_RatingObjects.png
+.. |File_Req_nr.png|                image:: Images/AdministratorManual/Typoscript/File_Req_nr.png
+.. |File_Req_r.png|                 image:: Images/AdministratorManual/Typoscript/File_Req_r.png
+.. |File_Req_cr.png|                image:: Images/AdministratorManual/Typoscript/File_Req_cr.png
+.. |File_Req_classic_starrating|    image:: Images/AdministratorManual/Typoscript/File_Req_classic_starrating.png
+.. |File_Req_barrating|             image:: Images/AdministratorManual/Typoscript/File_Req_barrating.png
+.. |File_Req_smiley|                image:: Images/AdministratorManual/Typoscript/File_Req_smiley.png
+.. |File_Req_tilt_barrating|        image:: Images/AdministratorManual/Typoscript/File_Req_tilt_barrating.png
+.. |File_Req_tilt_starrating|       image:: Images/AdministratorManual/Typoscript/File_Req_tilt_starrating.png
+.. |Typoscript_Ratinglink_tooltip|  image:: Images/AdministratorManual/Typoscript/Ratinglink_tooltip_example.png
+.. |ThRating_defaultLayout|         image:: Images/DeveloperInformation/ThRating_defaultLayout.gif
+.. |BE_RatingObjects.png|           image:: Images/Tutorial/BE_RatingObjects.png
    :alt: Ratingobjects
-   :align: top      
+   :align: top
    :width: 650
-.. |BE_createRatingObjects.png| 	image:: /Documentation/Images/Tutorial/BE_createRatingObjects.png
+.. |BE_createRatingObjects.png|     image:: Images/Tutorial/BE_createRatingObjects.png
    :alt: Create ratingobjects
-   :align: top      
+   :align: top
    :width: 465
-.. |BE_createRatingSteps.png| 		image:: /Documentation/Images/Tutorial/BE_createRatingSteps.png
+.. |BE_createRatingSteps.png|       image:: Images/Tutorial/BE_createRatingSteps.png
    :alt: Create ratingsteps
-   :align: top      
+   :align: top
    :width: 465
-.. |BE_createRatingStepname.png| 	image:: /Documentation/Images/Tutorial/BE_createRatingStepname.png
+.. |BE_createRatingStepname.png|    image:: Images/Tutorial/BE_createRatingStepname.png
    :alt: Create stepnames
-   :align: top      
+   :align: top
    :width: 465

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,59 +1,40 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: Includes.txt
 
 .. _start:
-	
+
 ====================
 EXT: Flexible Rating
 ====================
 
-.. only:: html
+:Classification:  th_rating
+:Version:         |release|
+:Language:        en
+:Description:
+   Highly flexible AJAX rating based on extbase/fluid/jquery. Allows multiple ratings
+   within one page. It could be used as a cObj by other extensions or included in every
+   FLUID template using the viewhelper. Each ratingstep could be configured having a name
+   - international localization included.
 
-   :Classification:
-   	th_rating
-   
-   :Version:
-   	|release|
-   
-   :Language:
-   	en
-   
-   :Description:
-   	Highly flexible AJAX rating based on extbase/fluid/jquery. Allows multiple ratings within one page. It could be used as a cObj by other extensions or included in every FLUID template using the viewhelper. Each ratingstep could be configured having a name - international localization included.
-   	
-   :Keywords:
-   	rating polling likeButton extbase fluid ajax jQuery
-   
-   :Author:
-   	Thomas Hucke
-   
-   :Email:
-   	thucke@web.de
-   
-   :Rendered:
-   	|today|
-   
-   :License:
-   	This document is published under the Open Content License
-   	available from http://www.opencontent.org/opl.shtml
+:Keywords:        rating polling likeButton extbase fluid ajax jQuery
+:Author:          Thomas Hucke
+:Email:           thucke@web.de
+:Rendered:        |today|
+:License:
+   This document is published under the Open Content License available from
+   http://www.opencontent.org/
 
-   The content of this document is related to TYPO3,
-   a GNU/GPL CMS/Framework available from `www.typo3.org <http://www.typo3.org/>`_.
+   The content of this document is related to TYPO3, a GNU/GPL CMS/Framework available
+   from https://typo3.org/
 
-
-   **Table of Contents**
 
 .. toctree::
-   :maxdepth: 3
-   :titlesonly:
-   :glob:
-   
+   :hidden:
+
+   Sitemap/Index
    Introduction/Index
    UsersManual/Index
    AdministratorManual/Index
    DeveloperInformation/Index
    Tutorial/Index
+   Linktargets/Index

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -4,7 +4,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _introduction:
 

--- a/Documentation/Linktargets/Index.rst
+++ b/Documentation/Linktargets/Index.rst
@@ -1,0 +1,25 @@
+.. include:: ../Includes.txt
+
+.. _Linktargets:
+
+===========
+Linktargets
+===========
+
+
+.. This is a comment to help you understand:
+
+   If you place a `.. _This-is-ABC:` in front of a headline
+   you are defining a linktarget that you can later link to like so:
+      :ref:`This-is-ABC`.
+
+   The directive `ref-targets-list` below creates an overview of the
+   linktargets defined in this documentation project.
+
+Understand: :ref:`About Intersphinx <t3wd:Intersphinx-How-to-link-to-topics-of-other-manuals>`
+
+
+Targets for Cross-Referencing
+
+.. ref-targets-list::
+

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -36,7 +36,7 @@ about_new_build = thucke@web.de
 
 # NOTE: Fill in YOUR values in the following!
 
-github_branch        = latest
+github_branch        = master
 github_commit_hash   =
 github_repository    = thucke/TYPO3.ext.th_rating
 github_revision_msg  =

--- a/Documentation/Sitemap/Index.rst
+++ b/Documentation/Sitemap/Index.rst
@@ -1,0 +1,11 @@
+:template: sitemap.html
+
+.. _Sitemap:
+
+=======
+Sitemap
+=======
+
+.. template 'sitemap.html' will insert the toctree as a sitemap here
+   below normal contents
+

--- a/Documentation/Tutorial/Creating ratingobjects.rst
+++ b/Documentation/Tutorial/Creating ratingobjects.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _tutorial-create-ratingobjects:
 
@@ -12,7 +12,7 @@ Creating ratingobjects
 
 Before a rating could be done at least one ratingobject must be created and configured with ratingsteps.
 
-Open your configured storage page in list view 
+Open your configured storage page in list view
 (see constant :ref:`plugin.tx_thrating.settings.pluginStoragePid <ts-constants>`)
 
 Add a new record of type ``ratingobjects``.
@@ -21,15 +21,15 @@ Add a new record of type ``ratingobjects``.
 
 |BE_createRatingObjects.png|
 
-Ratingobjects will be created automatically (see :ts:`pluginStoragePid` at :ref:`ts-constants`) 
-when doing the first rating of an object. Finally create your ratingsteps. 
+Ratingobjects will be created automatically (see :ts:`pluginStoragePid` at :ref:`ts-constants`)
+when doing the first rating of an object. Finally create your ratingsteps.
 Normal ratings require a ratingtep weight of value ``1``. This means all steps are rated equal.
 ``Ratingstep name`` could be given a value of your choice.
 
 |BE_createRatingSteps.png|
 
-You may also set a speaking text (Ratingstep name) for your ratingstep. 
-In multilanguage sites you could also configure language specific ratingstep names. 
+You may also set a speaking text (Ratingstep name) for your ratingstep.
+In multilanguage sites you could also configure language specific ratingstep names.
 If you want to do so please add the wanted site language to the storage page.
 
 |BE_createRatingStepname.png|

--- a/Documentation/Tutorial/Examples.rst
+++ b/Documentation/Tutorial/Examples.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _tutorial-examples:
 
@@ -59,18 +59,18 @@ CSS-file (fileadmin/templates/fullSize.css)
       padding:0px;
       margin:0px;
       line-height:125%;
-      font-family:verdana, arial, sans-serif; 
-      background-color:#FFFF; font-size:0.9em; 
+      font-family:verdana, arial, sans-serif;
+      background-color:#FFFF; font-size:0.9em;
    }
    .example {
       padding:20px;
       font-size:1.1em;
    }
-   .exampleBlock h2 {   
+   .exampleBlock h2 {
       color:#FF8700;
       font-weight:bold; font-size:1.0em;
       margin-bottom:0.5em; margin-top:1.3em;
-      white-space:nowrap; 
+      white-space:nowrap;
    }
 
 
@@ -83,7 +83,7 @@ The following seperates different template files for better structure.
 Main
 ^^^^
 
-This template must be activated as the root template of your TYPO3 installation. 
+This template must be activated as the root template of your TYPO3 installation.
 It should include all other template definitions.
 
 .. code-block:: typoscript
@@ -91,7 +91,7 @@ It should include all other template definitions.
 
    #replace this uid with the one on your site
    plugin.tx_felogin_pi1.storagePid = 3
-   
+
    config {
       no_cache = true
       removeDefaultJS = external
@@ -101,14 +101,14 @@ It should include all other template definitions.
       sys_language_mode = content_fallback;0
       sys_language_overlay = 1
       # Setting up the language variable "L" to be passed along with links
-      linkVars = L    
+      linkVars = L
 
       // configure default language
       sys_language_uid = 2
       language = en
       locale_all = en_GB.utf8
    }
-   
+
    # German language, sys_language.uid = 1
    [globalVar = GP:L = 1]
    config {
@@ -119,7 +119,7 @@ It should include all other template definitions.
       dateFormat = %x
       timeFormat = %X
    }
-   
+
    # English language, sys_language.uid = 2
    [globalVar = GP:L = 0]
    config {
@@ -130,7 +130,7 @@ It should include all other template definitions.
       dateFormat = %x
       timeFormat = %X
    }
-   
+
    [global]
 
 
@@ -143,7 +143,7 @@ Page definition
    page = PAGE
    page.typeNum = 0
    page.includeCSS.file = fileadmin/templates/fullSize.css
-   
+
    # Create a Fluid Template
    page.10 = FLUIDTEMPLATE
    page.10 {
@@ -246,17 +246,17 @@ Example content objects
 .. container::
 
    ==================================== ============================================
-   Example                              Description                                 
+   Example                              Description
    ==================================== ============================================
-   :ref:`tutEx1`                        Classic starrating       
-   :ref:`tutEx2`                        Smiley rating       
-   :ref:`tutEx3`                        Barrating       
-   :ref:`tutEx4`                        Vertical classic starrating       
-   :ref:`tutEx5`                        Current rating (text)       
-   :ref:`tutEx6`                        Current rating (classic starrating)       
-   :ref:`tutEx7`                        Vote form       
-   :ref:`tutEx8`                        Vertical rating       
-   :ref:`tutEx9`                        Polling mode       
+   :ref:`tutEx1`                        Classic starrating
+   :ref:`tutEx2`                        Smiley rating
+   :ref:`tutEx3`                        Barrating
+   :ref:`tutEx4`                        Vertical classic starrating
+   :ref:`tutEx5`                        Current rating (text)
+   :ref:`tutEx6`                        Current rating (classic starrating)
+   :ref:`tutEx7`                        Vote form
+   :ref:`tutEx8`                        Vertical rating
+   :ref:`tutEx9`                        Polling mode
    ==================================== ============================================
 
 

--- a/Documentation/Tutorial/Index.rst
+++ b/Documentation/Tutorial/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _tutorial:
 
@@ -15,7 +15,7 @@ Target group: **Administrators** and **Developers**
 The following pages are trying to give some explanations how to use Rating AX.
 
 Don't hesitate contacting the author if you miss something or if you would give some suggestions makings thins clearer.
-     
+
 
 .. toctree::
    :maxdepth: 3

--- a/Documentation/Tutorial/Making use of the viewhelper.rst
+++ b/Documentation/Tutorial/Making use of the viewhelper.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _tutorial-viewhelper:
 
@@ -34,4 +34,4 @@ Modify your FLUID template and include the extension viewhelper, e.g.:
 
 .. important::
 
-   CObject viewhelpers like those of Rating AX must be embedded in a ``<f:format.raw>`` viewhelper.  
+   CObject viewhelpers like those of Rating AX must be embedded in a ``<f:format.raw>`` viewhelper.

--- a/Documentation/Tutorial/Use signal - slot handler.rst
+++ b/Documentation/Tutorial/Use signal - slot handler.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _tutorial-signal-slot-handler:
 
@@ -25,9 +25,9 @@ Second you may create the file e.g. with the following content:
 
    <?
    if (!defined ('TYPO3_MODE'))    die ('Access denied.');
-   
+
    class tx_f4missions_main_signalHandler {
-   
+
       /**
        * Signal handler after a rating has bee created
        * Do timestamp update on changed entry and

--- a/Documentation/UsersManual/Index.rst
+++ b/Documentation/UsersManual/Index.rst
@@ -3,7 +3,7 @@
 .. --------------------------------------------------
 .. -*- coding: utf-8 -*- with BOM.
 
-.. include:: /Documentation/Includes.txt
+.. include:: ../Includes.txt
 
 .. _users-manual:
 
@@ -24,11 +24,11 @@ on pages as a content element.
 
 #. Configure your rating
 
-   The concerned ratingobject in that mode uses ``tt_content`` as tablename and ``uid`` as fieldname. You may first configure the ratingsteps you 
+   The concerned ratingobject in that mode uses ``tt_content`` as tablename and ``uid`` as fieldname. You may first configure the ratingsteps you
    like to have. Be aware using ongoing positive integer ratingorder numbers.
 
    |ManualContentElementObject.png|
-      
+
    If you are working on multilanguage websites you may add translations of your ratingsteps as usual:
 
    |ManualRatingstepMultilang.png|


### PR DESCRIPTION
This will make the documentation render without - fatal - errors.

But: The images will mostly be missing. You can only use relative path specifications. And since 'Includes.txt' is really handled as a textual inclusion at different points in the folder hierarchy the effective paths don't match. See the warnings.txt file.

Remedy:
- drop the image definitions from Includes.txt
- Instead of |nice_image.png| write .. figure:: ../relative/path/to/Images/nice_image.png wherever you want to use it
- Note: I would move the images to the folder where you use them. The just write: .. figure:: nice_image.png
- You CAN of course do that image definition |nice_image| in the file where you use it. But the relative path then in that file needs to be correct.
- The replacement technique for images is the only way to generate *inline* html images. Usually it's better to use the figure directive, since that can have a caption.

Tip:
- if you can use Docker, follow this readme: https://github.com/t3docs/docker-render-documentation

Heads up - it's going to work!