### PR TITLE
Allow null as getVoter return value

### DIFF
--- a/Classes/Domain/Model/Vote.php
+++ b/Classes/Domain/Model/Vote.php
@@ -162,9 +162,9 @@ class Vote extends AbstractEntity
     /**
      * Returns the frontenduser of this vote
      *
-     * @return \Thucke\ThRating\Domain\Model\Voter
+     * @return \Thucke\ThRating\Domain\Model\Voter|null
      */
-    public function getVoter(): Voter
+    public function getVoter(): ?Voter
     {
         return $this->voter;
     }


### PR DESCRIPTION
Currently there will be a TypeError if viewed when not logged in,
since getVoter would return null but has Voter as return value. Fixed by allowing null as return value.