### PR TITLE
Refactor automatic release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 
 name: Publish new version
 
+#run automatically when a new release is done
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [released]
 
 jobs:
   publish:
@@ -19,24 +19,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Check tag
-        run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-            exit 1
-          fi
       - name: Get version
         id: get-version
         run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+          
+      - name: Fetch release details from thucke/TYPO3.ext.th_rating
+        id: get_latest_release
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/${{ github.repository }}/releases/tags/${{ steps.get-version.outputs.version }}
+          owner: dummy
+          repo: TYPO3.ext.th_rating
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
 
-      - name: Get comment
-        id: get-comment
+      #see: https://trstringer.com/github-actions-multiline-strings/
+      #substituting the %, \n, and \r characters
+      - name: Store release body
+        id: set-release-body
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ steps.get-version.outputs.version }} | sed "s/^[0-9.]*[ ]*//g")
-          if [[ -z "${comment// }" ]]; then
-            echo ::set-output name=comment::Released version ${{ steps.get-version.outputs.version }} of ${{ env.TYPO3_EXTENSION_KEY }}
-          else
-            echo ::set-output name=comment::$comment
-          fi
+          RELEASE_BODY="${RELEASE_BODY//'%'/'%25'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\n'/'%0A'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\r'/'%0D'}"
+          echo ::set-output name=release_body::"$RELEASE_BODY"
+        env:
+          RELEASE_BODY: ${{ fromJson(steps.get_latest_release.outputs.data).body }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Now the release process uses the body information from the Github release page when publishing to TER.